### PR TITLE
Feature test meta server 3

### DIFF
--- a/hermes-core/pom.xml
+++ b/hermes-core/pom.xml
@@ -27,6 +27,11 @@
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-log4j12</artifactId>
 		</dependency>
+        <!--for Lease.class: JsonIgnore-->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
 		<!--netty -->
 		<dependency>
 			<groupId>io.netty</groupId>

--- a/hermes-core/src/main/java/com/ctrip/hermes/core/bo/HostPort.java
+++ b/hermes-core/src/main/java/com/ctrip/hermes/core/bo/HostPort.java
@@ -1,5 +1,7 @@
 package com.ctrip.hermes.core.bo;
 
+import java.util.Objects;
+
 public class HostPort {
 
 	private String m_host;
@@ -30,4 +32,17 @@ public class HostPort {
 		m_port = port;
 	}
 
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		HostPort hostPort = (HostPort) o;
+		return Objects.equals(m_port, hostPort.m_port) &&
+				  Objects.equals(m_host, hostPort.m_host);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(m_host, m_port);
+	}
 }

--- a/hermes-core/src/main/java/com/ctrip/hermes/core/lease/Lease.java
+++ b/hermes-core/src/main/java/com/ctrip/hermes/core/lease/Lease.java
@@ -5,6 +5,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import com.alibaba.fastjson.annotation.JSONField;
 import com.ctrip.hermes.core.service.SystemClockService;
 import com.ctrip.hermes.core.utils.PlexusComponentLocator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 
 /**
  * @author Leo Liang(jhliang@ctrip.com)
@@ -39,11 +40,13 @@ public class Lease {
 		return m_expireTime.get();
 	}
 
+	@JsonIgnore
 	@JSONField(serialize = false)
 	public boolean isExpired() {
 		return getRemainingTime() <= 0;
 	}
 
+	@JsonIgnore
 	@JSONField(serialize = false)
 	public long getRemainingTime() {
 		SystemClockService systemClockService = PlexusComponentLocator.lookup(SystemClockService.class);

--- a/hermes-metaserver/pom.xml
+++ b/hermes-metaserver/pom.xml
@@ -16,6 +16,12 @@
 			<groupId>com.ctrip.hermes</groupId>
 			<artifactId>hermes-metaservice</artifactId>
 		</dependency>
+        <!--need BrokerConfig in MetaServerBaseTest-->
+        <dependency>
+            <groupId>com.ctrip.hermes</groupId>
+            <artifactId>hermes-broker</artifactId>
+            <scope>test</scope>
+        </dependency>
 		<dependency>
 			<groupId>com.dianping.cat</groupId>
 			<artifactId>cat-client</artifactId>

--- a/hermes-metaserver/src/main/java/com/ctrip/hermes/metaserver/broker/BrokerAssignmentHolder.java
+++ b/hermes-metaserver/src/main/java/com/ctrip/hermes/metaserver/broker/BrokerAssignmentHolder.java
@@ -126,7 +126,7 @@ public class BrokerAssignmentHolder {
 			for (Map.Entry<String, Assignment<Integer>> entry : assignments.entrySet()) {
 				String topic = entry.getKey();
 				Assignment<Integer> topicAssignment = entry.getValue();
-				for (Map.Entry<Integer, Map<String, ClientContext>> partitionAssignment : topicAssignment.getAssigment()
+				for (Map.Entry<Integer, Map<String, ClientContext>> partitionAssignment : topicAssignment.getAssignment()
 				      .entrySet()) {
 					String path = ZKPathUtils.getBrokerAssignmentZkPath(topic, partitionAssignment.getKey());
 					try {

--- a/hermes-metaserver/src/main/java/com/ctrip/hermes/metaserver/commons/Assignment.java
+++ b/hermes-metaserver/src/main/java/com/ctrip/hermes/metaserver/commons/Assignment.java
@@ -10,31 +10,31 @@ import java.util.concurrent.ConcurrentHashMap;
  *
  */
 public class Assignment<Key> {
-	private Map<Key, Map<String, ClientContext>> m_assigment = new ConcurrentHashMap<>();
+	private Map<Key, Map<String, ClientContext>> m_assignment = new ConcurrentHashMap<>();
 
 	public boolean isAssignTo(Key key, String client) {
-		Map<String, ClientContext> clients = m_assigment.get(key);
+		Map<String, ClientContext> clients = m_assignment.get(key);
 		return clients != null && !clients.isEmpty() && clients.keySet().contains(client);
 	}
 
 	public Map<String, ClientContext> getAssignment(Key key) {
-		return m_assigment.get(key);
+		return m_assignment.get(key);
 	}
 
 	public void addAssignment(Key key, Map<String, ClientContext> clients) {
-		if (!m_assigment.containsKey(key)) {
-			m_assigment.put(key, new HashMap<String, ClientContext>());
+		if (!m_assignment.containsKey(key)) {
+			m_assignment.put(key, new HashMap<String, ClientContext>());
 		}
-		m_assigment.get(key).putAll(clients);
+		m_assignment.get(key).putAll(clients);
 	}
 
-	public Map<Key, Map<String, ClientContext>> getAssigment() {
-		return m_assigment;
+	public Map<Key, Map<String, ClientContext>> getAssignment() {
+		return m_assignment;
 	}
 
 	@Override
 	public String toString() {
-		return "Assignment [m_assigment=" + m_assigment + "]";
+		return "Assignment [m_assignment=" + m_assignment + "]";
 	}
 
 }

--- a/hermes-metaserver/src/main/java/com/ctrip/hermes/metaserver/commons/EndpointMaker.java
+++ b/hermes-metaserver/src/main/java/com/ctrip/hermes/metaserver/commons/EndpointMaker.java
@@ -46,7 +46,7 @@ public class EndpointMaker implements Initializable {
 		for (Map.Entry<String, Assignment<Integer>> topicAssignment : brokerAssignments.entrySet()) {
 
 			String topic = topicAssignment.getKey();
-			Map<Integer, Map<String, ClientContext>> assignment = topicAssignment.getValue().getAssigment();
+			Map<Integer, Map<String, ClientContext>> assignment = topicAssignment.getValue().getAssignment();
 
 			if (assignment != null && !assignment.isEmpty()) {
 

--- a/hermes-metaserver/src/main/java/com/ctrip/hermes/metaserver/commons/MetaStatusStatusResponse.java
+++ b/hermes-metaserver/src/main/java/com/ctrip/hermes/metaserver/commons/MetaStatusStatusResponse.java
@@ -1,0 +1,70 @@
+package com.ctrip.hermes.metaserver.commons;
+
+import java.util.Map;
+
+import org.unidal.tuple.Pair;
+
+import com.ctrip.hermes.core.bo.HostPort;
+import com.ctrip.hermes.core.bo.Tpg;
+
+public class MetaStatusStatusResponse {
+	private Boolean leader;
+
+	private HostPort leaderInfo;
+
+	private Map<String, Assignment<Integer>> brokerAssignments;
+
+	private Map<Pair<String, Integer>, Map<String, BaseLeaseHolder.ClientLeaseInfo>> brokerLeases;
+
+	private Map<Tpg, Map<String, BaseLeaseHolder.ClientLeaseInfo>> consumerLeases;
+
+	private Assignment<String> metaServerAssignments;
+
+	public Boolean isLeader() {
+		return leader;
+	}
+
+	public void setLeader(Boolean leader) {
+		this.leader = leader;
+	}
+
+	public Map<String, Assignment<Integer>> getBrokerAssignments() {
+		return brokerAssignments;
+	}
+
+	public void setBrokerAssignments(Map<String, Assignment<Integer>> brokerAssignments) {
+		this.brokerAssignments = brokerAssignments;
+	}
+
+	public Map<Pair<String, Integer>, Map<String, BaseLeaseHolder.ClientLeaseInfo>> getBrokerLeases() {
+		return brokerLeases;
+	}
+
+	public void setBrokerLeases(Map<Pair<String, Integer>, Map<String, BaseLeaseHolder.ClientLeaseInfo>> brokerLeases) {
+		this.brokerLeases = brokerLeases;
+	}
+
+	public Map<Tpg, Map<String, BaseLeaseHolder.ClientLeaseInfo>> getConsumerLeases() {
+		return consumerLeases;
+	}
+
+	public void setConsumerLeases(Map<Tpg, Map<String, BaseLeaseHolder.ClientLeaseInfo>> consumerLeases) {
+		this.consumerLeases = consumerLeases;
+	}
+
+	public HostPort getLeaderInfo() {
+		return leaderInfo;
+	}
+
+	public void setLeaderInfo(HostPort leaderInfo) {
+		this.leaderInfo = leaderInfo;
+	}
+
+	public Assignment<String> getMetaServerAssignments() {
+		return metaServerAssignments;
+	}
+
+	public void setMetaServerAssignments(Assignment<String> metaServerAssignments) {
+		this.metaServerAssignments = metaServerAssignments;
+	}
+}

--- a/hermes-metaserver/src/main/java/com/ctrip/hermes/metaserver/consumer/ConsumerAssignmentHolder.java
+++ b/hermes-metaserver/src/main/java/com/ctrip/hermes/metaserver/consumer/ConsumerAssignmentHolder.java
@@ -124,7 +124,7 @@ public class ConsumerAssignmentHolder implements Initializable {
 				Map<Integer, Map<String, ClientContext>> newAssignment = null;
 				if (consumerGroup.isOrderedConsume()) {
 					newAssignment = m_partitionAssigningStrategy.assign(partitions, consumers,
-					      originAssignment == null ? null : originAssignment.getAssigment());
+					      originAssignment == null ? null : originAssignment.getAssignment());
 				} else {
 					newAssignment = nonOrderedConsumeAssign(partitions, consumers);
 				}

--- a/hermes-metaserver/src/main/java/com/ctrip/hermes/metaserver/meta/DefaultMetaServerAssigningStrategy.java
+++ b/hermes-metaserver/src/main/java/com/ctrip/hermes/metaserver/meta/DefaultMetaServerAssigningStrategy.java
@@ -28,7 +28,10 @@ public class DefaultMetaServerAssigningStrategy implements MetaServerAssigningSt
 			int metaServerPos = 0;
 			int metaServerCount = metaServers.size();
 
-			if (topics != null) {
+			/**
+			 * add "&& metaServerCount > 0". If there is no metaServers running.
+			 */
+			if (topics != null && metaServerCount > 0) {
 				for (Topic topic : topics) {
 					if (Endpoint.BROKER.equals(topic.getEndpointType())) {
 						Server metaServer = metaServers.get(metaServerPos);

--- a/hermes-metaserver/src/main/java/com/ctrip/hermes/metaserver/meta/MetaServerAssignmentHolder.java
+++ b/hermes-metaserver/src/main/java/com/ctrip/hermes/metaserver/meta/MetaServerAssignmentHolder.java
@@ -106,7 +106,7 @@ public class MetaServerAssignmentHolder {
 
 	private void persistToZk(Assignment<String> assignments) {
 		if (assignments != null) {
-			for (Map.Entry<String, Map<String, ClientContext>> entry : assignments.getAssigment().entrySet()) {
+			for (Map.Entry<String, Map<String, ClientContext>> entry : assignments.getAssignment().entrySet()) {
 				String topic = entry.getKey();
 				Map<String, ClientContext> metaServers = entry.getValue();
 

--- a/hermes-metaserver/src/main/java/com/ctrip/hermes/metaserver/rest/resource/MetaServerResource.java
+++ b/hermes-metaserver/src/main/java/com/ctrip/hermes/metaserver/rest/resource/MetaServerResource.java
@@ -3,7 +3,6 @@ package com.ctrip.hermes.metaserver.rest.resource;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 
 import javax.inject.Singleton;
 import javax.ws.rs.GET;
@@ -12,18 +11,13 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response.Status;
 
-import org.unidal.tuple.Pair;
-
-import com.ctrip.hermes.core.bo.HostPort;
-import com.ctrip.hermes.core.bo.Tpg;
 import com.ctrip.hermes.core.utils.PlexusComponentLocator;
 import com.ctrip.hermes.meta.entity.Meta;
 import com.ctrip.hermes.meta.entity.Server;
 import com.ctrip.hermes.metaserver.broker.BrokerAssignmentHolder;
 import com.ctrip.hermes.metaserver.broker.BrokerLeaseHolder;
 import com.ctrip.hermes.metaserver.cluster.ClusterStateHolder;
-import com.ctrip.hermes.metaserver.commons.Assignment;
-import com.ctrip.hermes.metaserver.commons.BaseLeaseHolder.ClientLeaseInfo;
+import com.ctrip.hermes.metaserver.commons.MetaStatusStatusResponse;
 import com.ctrip.hermes.metaserver.consumer.ConsumerLeaseHolder;
 import com.ctrip.hermes.metaserver.meta.MetaHolder;
 import com.ctrip.hermes.metaserver.meta.MetaServerAssignmentHolder;
@@ -66,68 +60,5 @@ public class MetaServerResource {
 		response.setBrokerLeases(PlexusComponentLocator.lookup(BrokerLeaseHolder.class).getAllValidLeases());
 		response.setConsumerLeases(PlexusComponentLocator.lookup(ConsumerLeaseHolder.class).getAllValidLeases());
 		return response;
-	}
-
-	public static class MetaStatusStatusResponse {
-		private boolean m_leader;
-
-		private HostPort m_leaderInfo;
-
-		private Map<String, Assignment<Integer>> m_brokerAssignments;
-
-		private Map<Pair<String, Integer>, Map<String, ClientLeaseInfo>> m_brokerLeases;
-
-		private Map<Tpg, Map<String, ClientLeaseInfo>> m_consumerLeases;
-
-		private Assignment<String> m_metaServerAssignments;
-
-		public boolean isLeader() {
-			return m_leader;
-		}
-
-		public void setLeader(boolean leader) {
-			m_leader = leader;
-		}
-
-		public Map<String, Assignment<Integer>> getBrokerAssignments() {
-			return m_brokerAssignments;
-		}
-
-		public void setBrokerAssignments(Map<String, Assignment<Integer>> brokerAssignments) {
-			m_brokerAssignments = brokerAssignments;
-		}
-
-		public Map<Pair<String, Integer>, Map<String, ClientLeaseInfo>> getBrokerLeases() {
-			return m_brokerLeases;
-		}
-
-		public void setBrokerLeases(Map<Pair<String, Integer>, Map<String, ClientLeaseInfo>> brokerLeases) {
-			m_brokerLeases = brokerLeases;
-		}
-
-		public Map<Tpg, Map<String, ClientLeaseInfo>> getConsumerLeases() {
-			return m_consumerLeases;
-		}
-
-		public void setConsumerLeases(Map<Tpg, Map<String, ClientLeaseInfo>> consumerLeases) {
-			m_consumerLeases = consumerLeases;
-		}
-
-		public HostPort getLeaderInfo() {
-			return m_leaderInfo;
-		}
-
-		public void setLeaderInfo(HostPort leaderInfo) {
-			m_leaderInfo = leaderInfo;
-		}
-
-		public Assignment<String> getMetaServerAssignments() {
-			return m_metaServerAssignments;
-		}
-
-		public void setMetaServerAssignments(Assignment<String> metaServerAssignments) {
-			m_metaServerAssignments = metaServerAssignments;
-		}
-
 	}
 }

--- a/hermes-metaserver/src/test/java/com/ctrip/hermes/metaserver/AllTests.java
+++ b/hermes-metaserver/src/test/java/com/ctrip/hermes/metaserver/AllTests.java
@@ -4,12 +4,19 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
+import com.ctrip.hermes.metaserver.fulltest.*;
+
 @RunWith(Suite.class)
 @SuiteClasses({
-
+		  MetaServerBrokerAssignmentTest.class,
+		  MetaServerAssignmentTest.class,
+//		  MetaServerBaseMetaChangeTest.class,
+//		  MetaServerBrokerLeaseTest.class,
+//		  MetaServerConsumerLeaseTest.class,
+		  MetaServerLeadershipTest.class
 // add test classes here
 
 })
 public class AllTests {
-
+//
 }

--- a/hermes-metaserver/src/test/java/com/ctrip/hermes/metaserver/fulltest/HermesClassLoader.java
+++ b/hermes-metaserver/src/test/java/com/ctrip/hermes/metaserver/fulltest/HermesClassLoader.java
@@ -1,0 +1,78 @@
+package com.ctrip.hermes.metaserver.fulltest;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+
+public class HermesClassLoader extends URLClassLoader {
+	String[] customClasses;
+
+	public HermesClassLoader(URL[] urls, String... customClasses) {
+		super(urls);
+		this.customClasses = customClasses;
+	}
+
+	@Override
+	protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+		synchronized (getClassLoadingLock(name)) {
+			// First, check if the class has already been loaded
+			Class c = findLoadedClass(name);
+			if (c == null) {
+				/**
+				 * if isCustomClass try to load by itself, else delegate to its parent.
+				 */
+				if (isCustomClass(name)) {
+					try {
+						c = findClass(name);
+					} catch (Exception e) {
+						// ignore
+					}
+
+					if (c == null) {
+						try {
+							if (getParent() != null) {
+								c = getParent().loadClass(name);
+							}
+						} catch (ClassNotFoundException e) {
+							// ClassNotFoundException thrown if class not found
+							// from the non-null parent class loader
+						}
+					}
+				} else {
+					try {
+						if (getParent() != null) {
+							c = getParent().loadClass(name);
+						}
+					} catch (ClassNotFoundException e) {
+						// ClassNotFoundException thrown if class not found
+						// from the non-null parent class loader
+					}
+
+					if (c == null) {
+						try {
+							c = findClass(name);
+						} catch (Exception e) {
+							// ignore
+						}
+					}
+				}
+
+			}
+			if (resolve) {
+				resolveClass(c);
+			}
+			return c;
+		}
+	}
+
+	private boolean isCustomClass(String name) {
+		boolean isCustom = false;
+		for (String customClass : customClasses) {
+			if (name.startsWith(customClass)) {
+				isCustom = true;
+				break;
+			}
+		}
+		return isCustom;
+	}
+
+}

--- a/hermes-metaserver/src/test/java/com/ctrip/hermes/metaserver/fulltest/HermesClassLoaderMetaServer.java
+++ b/hermes-metaserver/src/test/java/com/ctrip/hermes/metaserver/fulltest/HermesClassLoaderMetaServer.java
@@ -1,0 +1,95 @@
+package com.ctrip.hermes.metaserver.fulltest;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.net.URLClassLoader;
+import java.util.EventListener;
+
+import org.mortbay.jetty.Handler;
+import org.mortbay.jetty.Server;
+import org.mortbay.jetty.servlet.ServletHolder;
+import org.mortbay.jetty.webapp.WebAppClassLoader;
+import org.mortbay.jetty.webapp.WebAppContext;
+import org.mortbay.servlet.GzipFilter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.unidal.lookup.ContainerHolder;
+import org.unidal.test.jetty.ResourceFallbackWebAppContext;
+import org.unidal.test.jetty.WebModuleResource;
+import org.unidal.test.jetty.WebModuleServlet;
+
+public class HermesClassLoaderMetaServer extends ContainerHolder {
+	private static final Logger log = LoggerFactory.getLogger(HermesClassLoaderMetaServer.class);
+
+	int port;
+
+	private Server m_server;
+	private WebModuleResource m_resource;
+
+	public HermesClassLoaderMetaServer(int port) {
+		this.port = port;
+	}
+
+	public void startServer() throws Exception {
+		Server server = new Server(port);
+		WebAppContext context = new ResourceFallbackWebAppContext();
+
+		configure(context);
+		ClassLoader parent = new HermesClassLoader(((URLClassLoader) this.getClass().getClassLoader()).getURLs(),
+				  "com.ctrip.", "com.dianping.", "org.unidal.");
+
+		context.setClassLoader(new WebAppClassLoader(parent, context));
+		context.addServlet(new ServletHolder(new WebModuleServlet(m_resource)), "/");
+
+
+		// find LoadMocksListener with HermesClassLoader
+		Class clazz = parent.loadClass("com.ctrip.hermes.metaserver.fulltest.LoadMocksListener");
+		Object obj = clazz.newInstance();
+		Field field = clazz.getDeclaredField("port");
+		field.setAccessible(true);
+		field.set(obj, port);
+		context.addEventListener((EventListener) obj);
+
+		server.addHandler(context);
+		try {
+			server.start();
+		} catch (java.net.BindException e) {
+			log.warn("CustomClassLoaderMetaServer[localhost:{}] start fail, BindException.", port);
+		}
+
+		postConfigure(context);
+
+		m_server = server;
+	}
+
+	public void stopServer() throws Exception {
+		m_server.stop();
+	}
+
+	@SuppressWarnings("unchecked")
+	protected void configure(WebAppContext context) throws Exception {
+		File warRoot = getWarRoot();
+
+		m_resource = new WebModuleResource(warRoot);
+		context.getInitParams().put("org.mortbay.jetty.servlet.Default.dirAllowed", "false");
+		context.setContextPath(getContextPath());
+		context.setDescriptor(new File(warRoot, "WEB-INF/web.xml").getPath());
+		context.setBaseResource(m_resource);
+	}
+
+	protected File getWarRoot() {
+		File file = new File("src/main/webapp");
+		if (! file.exists()) {
+			file = new File("hermes-metaserver/src/main/webapp");
+		}
+		return file;
+	}
+
+	protected void postConfigure(WebAppContext context) {
+		context.addFilter(GzipFilter.class, "/*", Handler.ALL);
+	}
+
+	protected String getContextPath() {
+		return "/";
+	}
+}

--- a/hermes-metaserver/src/test/java/com/ctrip/hermes/metaserver/fulltest/LoadMocksListener.java
+++ b/hermes-metaserver/src/test/java/com/ctrip/hermes/metaserver/fulltest/LoadMocksListener.java
@@ -1,0 +1,46 @@
+package com.ctrip.hermes.metaserver.fulltest;
+
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+
+import org.unidal.lookup.ContainerLoader;
+
+import com.ctrip.hermes.core.env.ClientEnvironment;
+import com.ctrip.hermes.core.utils.PlexusComponentLocator;
+import com.ctrip.hermes.metaserver.config.MetaServerConfig;
+import com.ctrip.hermes.metaservice.service.MetaService;
+
+/**
+ * used in HermesClassLoaderMetaServer:
+ * 		Class clazz = parent.loadClass("com.ctrip.hermes.metaserver.fulltest.LoadMocksListener");
+ */
+public class LoadMocksListener extends MetaServerBaseTest implements ServletContextListener {
+
+	int port;
+
+	public void setPort(int port) {
+		this.port = port;
+	}
+
+	@Override
+	public void contextInitialized(ServletContextEvent servletContextEvent) {
+		try {
+			initPlexus();
+			// for mock
+			defineComponent(MetaServerConfig.class, MockMetaServerConfig.class).req(ClientEnvironment.class);
+			defineComponent(MetaService.class, MockMetaService.class);
+			defineComponent(ClientEnvironment.class, MockClientEnviroment.class);
+
+			// end of mock
+			MockMetaServerConfig config = (MockMetaServerConfig) PlexusComponentLocator.lookup(MetaServerConfig.class);
+			config.setPort(port);
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+
+	@Override
+	public void contextDestroyed(ServletContextEvent servletContextEvent) {
+		ContainerLoader.destroyDefaultContainer();
+	}
+}

--- a/hermes-metaserver/src/test/java/com/ctrip/hermes/metaserver/fulltest/MetaServerAssignmentTest.java
+++ b/hermes-metaserver/src/test/java/com/ctrip/hermes/metaserver/fulltest/MetaServerAssignmentTest.java
@@ -1,0 +1,45 @@
+package com.ctrip.hermes.metaserver.fulltest;
+
+import org.junit.Test;
+
+import com.ctrip.hermes.core.utils.PlexusComponentLocator;
+import com.ctrip.hermes.meta.entity.Topic;
+import com.ctrip.hermes.metaservice.service.ZookeeperService;
+
+public class MetaServerAssignmentTest extends MetaServerBaseTest  {
+	/**
+	 * MetaServer新增，减少: 默认将Topic-Group分配到各MetaServer上
+	 */
+	@Test
+	public void testMetaServerAssignment() throws Exception {
+		int initServers = 2;
+		int topicCount = 5;
+
+		// init
+		startMultipleMetaServers(initServers);
+		assertOnlyOneLeader();
+
+		// add topic
+		for (int i = 0; i < topicCount; i++) {
+			addOneTopicToMeta();
+			assertMetaServerAssignmentRight();
+		}
+
+		// remove topic
+		for (int i = 0; i < topicCount; i++) {
+			Topic removedTopic = removeOneTopicFromMeta();
+
+			// mock delete this topic on Portal
+			if (null != removedTopic) {
+				PlexusComponentLocator.lookup(ZookeeperService.class).
+						  deleteMetaServerAssignmentZkPath(removedTopic.getName());
+				assertMetaServerAssignmentRight();
+			}
+		}
+
+		// stop all servers
+		stopMultipleMetaServersRandomly(initServers);
+		assertAllStopped();
+	}
+
+}

--- a/hermes-metaserver/src/test/java/com/ctrip/hermes/metaserver/fulltest/MetaServerBaseMetaChangeTest.java
+++ b/hermes-metaserver/src/test/java/com/ctrip/hermes/metaserver/fulltest/MetaServerBaseMetaChangeTest.java
@@ -1,0 +1,42 @@
+package com.ctrip.hermes.metaserver.fulltest;
+
+import org.junit.Test;
+
+import com.ctrip.hermes.meta.entity.Topic;
+
+public class MetaServerBaseMetaChangeTest extends MetaServerBaseTest  {
+	/**
+	 *  BaseMeta/Broker/MetaServer Changes on one Topic
+	 */
+	@Test
+	public void testBaseMetaChanged() throws Exception {
+		int initServers = 3;
+
+		// init
+		startMultipleMetaServers(initServers);
+		assertOnlyOneLeader();
+
+		// baseMeta changed
+		Topic topic = TopicHelper.buildRandomTopic();
+
+		baseMetaCreateTopic(topic);
+		Thread.sleep(2500); //wait metaServers notice the ZK change
+
+		assertAllMetaServerHaveTopic(topic);
+
+		topic = TopicHelper.buildUpdatedTopic(topic);
+		baseMetaUpdateTopic(topic);
+		assertAllMetaServerHaveTopic(topic);
+
+		baseMetaDeleteTopic(topic);
+		Thread.sleep(2500); //wait metaServers notice the ZK change
+
+		assertAllMetaServerHaveNotTopic(topic);
+
+		// stop all servers
+		stopMultipleMetaServersRandomly(initServers);
+		assertAllStopped();
+	}
+
+
+}

--- a/hermes-metaserver/src/test/java/com/ctrip/hermes/metaserver/fulltest/MetaServerBaseTest.java
+++ b/hermes-metaserver/src/test/java/com/ctrip/hermes/metaserver/fulltest/MetaServerBaseTest.java
@@ -1,0 +1,791 @@
+package com.ctrip.hermes.metaserver.fulltest;
+
+import java.io.*;
+import java.net.URISyntaxException;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+
+import org.apache.curator.test.TestingServer;
+import org.apache.curator.x.discovery.ServiceDiscovery;
+import org.apache.curator.x.discovery.ServiceDiscoveryBuilder;
+import org.apache.curator.x.discovery.ServiceInstance;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.fluent.Request;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.entity.ContentType;
+import org.apache.http.util.EntityUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.unidal.lookup.ComponentTestCase;
+import org.unidal.net.Networks;
+import org.xml.sax.SAXException;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.TypeReference;
+import com.ctrip.hermes.broker.config.BrokerConfig;
+import com.ctrip.hermes.broker.zk.ZKClient;
+import com.ctrip.hermes.core.bo.HostPort;
+import com.ctrip.hermes.core.bo.Tpg;
+import com.ctrip.hermes.core.lease.Lease;
+import com.ctrip.hermes.core.lease.LeaseAcquireResponse;
+import com.ctrip.hermes.core.utils.PlexusComponentLocator;
+import com.ctrip.hermes.core.utils.StringUtils;
+import com.ctrip.hermes.meta.entity.Endpoint;
+import com.ctrip.hermes.meta.entity.Meta;
+import com.ctrip.hermes.meta.entity.Partition;
+import com.ctrip.hermes.meta.entity.Topic;
+import com.ctrip.hermes.meta.transform.DefaultSaxParser;
+import com.ctrip.hermes.meta.transform.DefaultXmlBuilder;
+import com.ctrip.hermes.metaserver.commons.Assignment;
+import com.ctrip.hermes.metaserver.commons.ClientContext;
+import com.ctrip.hermes.metaserver.commons.MetaStatusStatusResponse;
+import com.ctrip.hermes.metaservice.service.ZookeeperService;
+import com.ctrip.hermes.metaservice.zk.ZKPathUtils;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.junit.Assert.*;
+
+
+public class MetaServerBaseTest extends ComponentTestCase {
+	private static final Logger logger = LoggerFactory.getLogger(MetaServerBaseTest.class);
+
+	public static final String metaXmlFile = "MetaServerTest.xml";
+	public static final String metaXmlFileBackup = "MetaServerTest_Backup.xml";
+
+	private ZookeeperService zkService;
+	private BrokerConfig m_config;
+	private ZKClient m_client;
+	private TestingServer m_zkServer;
+
+	/*
+	initial value is based on  "meta-port" in hermes.properties.
+	 */
+	protected static int portPointer = 1248;
+	protected static List<Integer> ports = new ArrayList<>();
+	protected static AtomicInteger zkVersion = new AtomicInteger(10000);
+
+
+	protected static AtomicInteger brokerPort = new AtomicInteger(5000);
+	protected Map<Integer/*port*/, HermesClassLoaderMetaServer/*meta server*/> metaServers = new HashMap<>();
+	protected Map<Integer/*port*/, ServiceDiscovery<Void>/*broker serviceDiscovery*/> tempBrokers = new HashMap<>();
+	protected Stack<Topic> tempTopics = new Stack<>();
+	protected static String localhostIP = Networks.forIp().getLocalHostAddress();
+
+	@Before
+	public void setUp() throws Exception {
+		cleanEnv();
+
+		startZKServer();
+		initMetaXmlAndService();
+		setupZKNodes();
+	}
+
+	private void cleanEnv() throws Exception {
+		portPointer = 1248;
+		ports = new ArrayList<>();
+		zkVersion = new AtomicInteger(10000);
+		brokerPort = new AtomicInteger(5000);
+
+		metaServers.clear();
+		tempBrokers.clear();
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		// close all meta servers anyway
+		stopMultipleMetaServersRandomly(Integer.MAX_VALUE);
+		if (null != m_zkServer) {
+			m_zkServer.close();
+			logger.info("==ZKServer== Zookeeper Server Closed");
+		} else {
+			logger.info("==ZKServer== Zookeeper is Null. No Need to Close.");
+		}
+
+		super.tearDown();
+	}
+
+	public void initPlexus() throws Exception {
+		super.setUp();
+	}
+
+	public void initMetaXmlAndService() throws Exception {
+		MetaHelper.outputToTestXml(MetaHelper.loadMeta(metaXmlFileBackup));
+
+		zkService = PlexusComponentLocator.lookup(ZookeeperService.class);
+		m_config = PlexusComponentLocator.lookup(BrokerConfig.class);
+		m_client = PlexusComponentLocator.lookup(ZKClient.class);
+	}
+
+	protected void startMetaServer(int port) throws Exception {
+		HermesClassLoaderMetaServer metaServer = new HermesClassLoaderMetaServer(port);
+		metaServer.startServer();
+
+		metaServers.put(port, metaServer);
+	}
+
+	protected void stopMetaServer(int port) throws Exception {
+		HermesClassLoaderMetaServer metaServer = metaServers.get(port);
+		if (metaServer == null) {
+			throw new Exception(String.format("MetaServer: localhost:%d, not found!", port));
+		} else {
+			metaServer.stopServer();
+			metaServers.remove(port);
+		}
+	}
+
+	private void setupZKNodes() throws Exception {
+		ZookeeperService zkService = PlexusComponentLocator.lookup(ZookeeperService.class);
+
+		Meta meta = new MockMetaService().findLatestMeta();
+		for (Topic topic : meta.getTopics().values()) {
+			if (Endpoint.BROKER.equals(topic.getEndpointType())) {
+				zkService.ensureBrokerLeaseZkPath(topic);
+				zkService.ensureConsumerLeaseZkPath(topic);
+			}
+		}
+		zkService.updateZkBaseMetaVersion(meta.getVersion());
+
+		zkService.updateZkBaseMetaVersion(MetaServerBaseTest.zkVersion.getAndIncrement());
+
+		zkService.ensurePath(ZKPathUtils.getMetaInfoZkPath());
+		zkService.ensurePath(ZKPathUtils.getBrokerLeasesZkPath());
+		zkService.ensurePath(ZKPathUtils.getMetaServerAssignmentRootZkPath());
+		zkService.ensurePath(ZKPathUtils.getBrokerAssignmentRootZkPath());
+		zkService.ensurePath(ZKPathUtils.getConsumerLeaseRootZkPath());
+	}
+
+	protected void startMultipleMetaServers(int number) throws Exception {
+		for (int i = 0; i < number; i++) {
+			startMetaServer(portPointer);
+			ports.add(portPointer);
+			portPointer++;
+		}
+	}
+
+	protected void stopMultipleMetaServersRandomly(int number) throws Exception {
+		int closeNumber = getRightCloseNumber(number);
+		for (int i = 0; i < closeNumber; i++) {
+			int randomIndex = new Random().nextInt(ports.size());
+			int randomPort = ports.get(randomIndex);
+			stopMetaServer(randomPort);
+			ports.remove(randomIndex);
+			logger.info("==StopMetaServer== Trying to Stop Meta Server : {}. Remaining are {}", randomPort, ports);
+		}
+	}
+
+	private int getRightCloseNumber(int number) {
+		int closeNumber = number;
+		if (number > metaServers.size()) {
+			logger.warn("Want to stop {} metaservsers, but only {} running. Will close them all.", number, metaServers
+					  .size());
+			closeNumber = metaServers.size();
+		}
+		return closeNumber;
+	}
+
+	protected void startZKServer() throws Exception {
+		startZKServer(2181);
+	}
+
+	protected void startZKServer(int port) throws Exception {
+		try {
+			m_zkServer = new TestingServer(port);
+			m_zkServer.restart();
+			logger.info("==Start ZKServer== on port {} Success.", port);
+
+		} catch (java.net.BindException e) {
+			logger.warn("==Start ZKServer== on port {} failed. BindException.", port);
+		}
+	}
+
+	protected void assertOnlyOneLeader() throws InterruptedException, IOException {
+		Thread.sleep(3000);
+		List<String> expectedServers = buildExpectedServers(metaServers);
+
+		// 1. check /metaservers/server for all metaservers
+		for (Map.Entry<Integer, HermesClassLoaderMetaServer> entry : metaServers.entrySet()) {
+			assertListEqual(expectedServers, BaseRestClient.getMetaServers(entry.getKey()));
+		}
+
+		// 2. check /metaservers/status for the right and only one leader
+		int leaderCount = 0;
+		HostPort leader = null;
+		HostPort trueLeader = null;
+		for (Map.Entry<Integer, HermesClassLoaderMetaServer> entry : metaServers.entrySet()) {
+			MetaStatusStatusResponse re = BaseRestClient.getMetaStatusLeaderInfo(entry.getKey());
+			if (re.isLeader()) {
+				leaderCount++;
+				trueLeader = re.getLeaderInfo();
+				leader = re.getLeaderInfo();
+			} else {
+				if (leader != null) {
+					assertEquals(leader, re.getLeaderInfo());
+				} else {
+					leader = re.getLeaderInfo();
+				}
+			}
+		}
+
+		assertEquals(1, leaderCount);
+		assertEquals(leader, trueLeader);
+		logger.info("==LeaderShip== Only One Leader {} Among {} Meta Servers", trueLeader.getPort(), metaServers.size());
+	}
+
+	protected void assertAllMetaServerHaveTopic(Topic topic) {
+		for (Map.Entry<Integer, HermesClassLoaderMetaServer> entry : metaServers.entrySet()) {
+			Meta meta = BaseRestClient.getMeta(entry.getKey());
+			Map<String, Topic> topics = meta.getTopics();
+
+			assertTrue(topics.containsKey(topic.getName()));
+			assertTrue(topics.containsValue(topic));
+		}
+	}
+
+	protected void assertAllMetaServerHaveNotTopic(Topic topic) {
+		for (Map.Entry<Integer, HermesClassLoaderMetaServer> entry : metaServers.entrySet()) {
+			Meta meta = BaseRestClient.getMeta(entry.getKey());
+			Map<String, Topic> topics = meta.getTopics();
+
+			assertFalse(topics.containsKey(topic.getName()));
+			assertFalse(topics.containsValue(topic));
+		}
+	}
+
+	protected void assertBrokerAssignmentRight() throws Exception {
+		// wait a while to assign. set to 2 second for slow machine in CI.
+		Thread.sleep(2000);
+
+		List<Topic> topics = new ArrayList<>(MetaHelper.loadMeta().getTopics().values());
+
+		for (Integer port : metaServers.keySet()) {
+			MetaStatusStatusResponse re = BaseRestClient.getMetaStatusBrokerAssignment(port);
+
+			// only Leader has Broker Assignment Info.
+			if (re.isLeader()) {
+				if (tempBrokers.size() > 0) { // means at lease one broker be assigned.
+					assertEquals("Topics.size() should be equal to Broker Assignments",
+							  topics.size(), re.getBrokerAssignments().size());
+				}
+				List<Integer> runningBrokers = getRunningBrokers(re.getBrokerAssignments());
+
+				int writeBrokerCount = topics.size() < tempBrokers.keySet().size() ?
+						  topics.size() : tempBrokers.keySet().size();
+				assertEquals(writeBrokerCount, runningBrokers.size());
+			}
+		}
+	}
+
+	private List<Integer> getRunningBrokers(Map<String, Assignment<Integer>> brokerAssignments) {
+		Set<Integer> ports = new HashSet<>();
+		for (Assignment<Integer> assignment : brokerAssignments.values()) {
+			for (Map<String, ClientContext> map : assignment.getAssignment().values()) {
+				for (Object o : map.values()) {
+					Map clientContext = JSON.parseObject(JSON.toJSONString(o), Map.class);
+					int port = (int) clientContext.get("port");
+					ports.add(port);
+				}
+			}
+		}
+		return new ArrayList<>(ports);
+	}
+
+	protected void assertMetaServerAssignmentRight() throws Exception {
+		Thread.sleep(500);
+		List<Topic> topics = new ArrayList<>(MetaHelper.loadMeta().getTopics().values());
+
+		for (Integer port : metaServers.keySet()) {
+			MetaStatusStatusResponse re = BaseRestClient.getMetaStatusMetaServerAssignment(port);
+			assertEquals("Topics.size() should be equal to MetaServer Assignments",
+					  topics.size(), re.getMetaServerAssignments().getAssignment().size());
+
+//			ArrayList<Integer> runningMetaServers = getRunningMetaServers(re.getMetaServerAssignments().getAssignment());
+//			assertListEqual(new ArrayList<>(metaServers.keySet()), runningMetaServers);
+		}
+	}
+
+	private ArrayList<Integer> getRunningMetaServers(Map<String, Map<String, ClientContext>> assignment) {
+		Set<Integer> ports = new HashSet<>();
+		for (Map<String, ClientContext> map : assignment.values()) {
+
+			// CAN'T cast map.values() to ClientContext, 'cause the classLoader of ClientContext is HermesClassLoader!
+			for (Object o : map.values()) {
+				Map clientContext = JSON.parseObject(JSON.toJSONString(o), Map.class);
+				int port = (int) clientContext.get("port");
+				ports.add(port);
+			}
+		}
+		return new ArrayList<>(ports);
+	}
+
+	private void assertListEqual(List list1, List list2) {
+		assertEquals(list1.size(), list2.size());
+
+		Set set1 = new HashSet(list1);
+		Set set2 = new HashSet(list2);
+		assertEquals(set1, set2);
+	}
+
+	// ============= Broker Lease================
+	protected Lease initLeaseToBroker(int brokerPort, String topic, int partition, String sessionId)
+			  throws Exception {
+		LeaseAcquireResponse re = BaseRestClient.getAcquireBrokerLease(topic, partition, sessionId, brokerPort, 1248);
+
+		return re.getLease();
+	}
+
+	protected Lease changeLeaseTo(int fromBrokerPort, int toBrokerPort, String topic, int partition, long
+			  timeoutInMs) throws Exception {
+		// 方法1，用BrokerAssignmentHolder重新分配, 无法生效：因现状Reassign策略是取所有可用Broker做遍历均分。
+
+		// 方法2，把Broker1挂掉。
+		tempBrokers.get(fromBrokerPort).close();
+
+		Thread.sleep(1000); // wait a while for ZK service discovery
+		return null;
+	}
+
+	protected void assertAcquireBrokerLeaseOnAll(boolean expected, int brokerPort,
+																String topic, int partition, String sessionId) throws Exception {
+		for (Integer port : metaServers.keySet()) {
+			assertEquals(String.format("MetaServer:%d, acquire should be %s. ", port, expected),
+					  expected, acquireBrokerLease(brokerPort, topic, partition, sessionId, port));
+		}
+	}
+
+	private boolean acquireBrokerLease(int brokerPort, String topic, int partition, String
+			  sessionId, Integer metaServerPort) throws Exception {
+		LeaseAcquireResponse lease = BaseRestClient.getAcquireBrokerLease(topic, partition, sessionId, brokerPort,
+				  metaServerPort);
+
+		return lease.isAcquired();
+	}
+
+	protected void assertRenewBrokerLeaseOnAll(boolean expected, int brokerPort, String topic, int partition, long
+			  leaseId, String sessionId) throws IOException, URISyntaxException {
+		for (Integer port : metaServers.keySet()) {
+			assertEquals(expected, renewBrokerLease(brokerPort, topic, partition, leaseId, sessionId, port));
+		}
+	}
+
+	private boolean renewBrokerLease(int brokerPort, String topic, int partition, long leaseId, String sessionId,
+												Integer metaServerPort) throws IOException, URISyntaxException {
+		LeaseAcquireResponse lease = BaseRestClient.getRenewBrokerLease(topic, partition, leaseId, sessionId,
+				  brokerPort, metaServerPort);
+		logger.info("==Renew Lease== for Broker-Port:{}, Broker-Session:{} on Meta:{}. Got Lease:{}, isExpired:{}",
+				  brokerPort, sessionId, metaServerPort, lease, lease.getLease() == null ? null : lease.getLease().isExpired());
+		return lease.isAcquired();
+	}
+
+	protected void assertAcquireConsumerLeaseOnAll(boolean expected, String topic, String group) throws IOException,
+			  URISyntaxException, InterruptedException {
+		for (Integer port : metaServers.keySet()) {
+
+			// will fail at first time to acquire lease!
+			acquireConsumerLease(port, topic, group);
+			Thread.sleep(2000);
+
+			assertEquals(expected, acquireConsumerLease(port, topic, group));
+		}
+	}
+
+	private boolean acquireConsumerLease(Integer metaServerPort, String topic, String group) throws IOException,
+			  URISyntaxException {
+		Tpg tpg = new Tpg();
+		tpg.setTopic(topic);
+		tpg.setGroupId(group);
+
+		return BaseRestClient.getAcquireConsumerLease(metaServerPort, tpg).isAcquired();
+	}
+
+	protected void assertRenewConsumerLeaseOnAll(boolean expected, long leaseId, String topic, String group) throws
+			  IOException,
+			  URISyntaxException {
+		for (Integer port : metaServers.keySet()) {
+			assertEquals(expected, renewConsumerLease(port, leaseId, topic, group));
+		}
+	}
+
+	private boolean renewConsumerLease(Integer metaServerPort, long leaseId, String topic, String group) throws
+			  IOException, URISyntaxException {
+		Tpg tpg = new Tpg();
+		tpg.setTopic(topic);
+		tpg.setGroupId(group);
+
+		return BaseRestClient.getRenewConsumerLease(metaServerPort, leaseId, tpg).isAcquired();
+	}
+
+	protected List<Integer> mockBrokerRegisterToZK(int brokerCount) throws Exception {
+		List<Integer> ports = new ArrayList<>();
+		for (int i = 0; i < brokerCount; i++) {
+			ports.add(brokerRegisterToZK());
+		}
+		return ports;
+	}
+
+	protected void mockBrokerAllUnRegisterToZK() throws IOException {
+		for (ServiceDiscovery<Void> serviceDiscovery : tempBrokers.values()) {
+			serviceDiscovery.close();
+		}
+		tempBrokers.clear();
+	}
+
+	// copied from DefaultBrokerRegistry
+	// set session_id to the broker port!
+	private int brokerRegisterToZK() throws Exception {
+		int port = brokerPort.getAndIncrement();
+		ServiceInstance<Void> thisInstance = ServiceInstance.<Void>builder()//
+				  .name(m_config.getRegistryName(null))//
+				  .address(localhostIP)//
+				  .port(port)//
+				  .id(String.valueOf(port))//
+				  .build();
+
+		ServiceDiscovery<Void> m_serviceDiscovery = ServiceDiscoveryBuilder.builder(Void.class)//
+				  .client(m_client.getClient())//
+				  .basePath(m_config.getRegistryBasePath())//
+				  .thisInstance(thisInstance)//
+				  .build();
+		m_serviceDiscovery.start();
+
+		tempBrokers.put(port, m_serviceDiscovery);
+		return port;
+	}
+
+	private List<String> buildExpectedServers(Map<Integer, HermesClassLoaderMetaServer> metaServers) {
+		List<String> result = new ArrayList<>();
+		for (Integer port : metaServers.keySet()) {
+			result.add(localhostIP + ":" + port);
+		}
+		return result;
+	}
+
+	protected void assertAllStopped() {
+		assertEquals(0, metaServers.size());
+	}
+
+	protected void addOneTopicToMeta(String name) throws Exception {
+		Topic topic = TopicHelper.buildTopic(name);
+		tempTopics.push(topic);
+
+		baseMetaCreateTopic(topic);
+	}
+
+	protected void addOneTopicToMeta() throws Exception {
+		Topic topic = TopicHelper.buildRandomTopic();
+		tempTopics.push(topic);
+
+		baseMetaCreateTopic(topic);
+	}
+
+	protected Topic removeOneTopicFromMeta() throws Exception {
+		Topic topic = null;
+		if (!tempTopics.isEmpty()) {
+			topic = tempTopics.pop();
+			baseMetaDeleteTopic(topic);
+		}
+		return topic;
+	}
+
+	protected void baseMetaCreateTopic(Topic topic) throws Exception {
+		Meta meta = MetaHelper.loadMeta();
+		meta.addTopic(topic);
+
+		updateVersionAndOutputAndUpdateZKVersion(meta);
+	}
+
+	protected void baseMetaUpdateTopic(Topic topic) throws Exception {
+		Meta meta = MetaHelper.loadMeta();
+		meta.removeTopic(topic.getName());
+		topic.setLastModifiedTime(new Date(System.currentTimeMillis()));
+		meta.addTopic(topic);
+
+		updateVersionAndOutputAndUpdateZKVersion(meta);
+	}
+
+	private void updateVersionAndOutputAndUpdateZKVersion(Meta meta) throws Exception {
+		meta.setVersion(meta.getVersion() + 1);
+
+		MetaHelper.outputToTestXml(meta);
+		zkService.updateZkBaseMetaVersion(zkVersion.getAndIncrement());
+	}
+
+	protected void baseMetaDeleteTopic(Topic topic) throws Exception {
+		Meta meta = MetaHelper.loadMeta();
+		meta.removeTopic(topic.getName());
+
+		updateVersionAndOutputAndUpdateZKVersion(meta);
+	}
+
+	protected void waitOneLeaseTime() throws InterruptedException {
+		long time = MockMetaServerConfig.BROKER_LEASE_TIMEOUT + 500;
+		// Timeout time change to 3000 in MockMetaServerConfig
+		logger.info("==Wait {} ms to Timeout", time);
+		Thread.sleep(time);
+	}
+
+
+	static class TopicHelper {
+		protected static Topic buildRandomTopic() {
+			return buildTopic(String.valueOf(new Random().nextInt(1000)));
+		}
+
+		protected static Topic buildTopic(String name) {
+			Topic topic = new Topic(name);
+			topic.setAckTimeoutSeconds(555);
+			topic.setCodecType("json");
+			topic.setConsumerRetryPolicy("1:[3,6,9]");
+			topic.setCreateBy("hermes");
+			topic.setCreateTime(new Date());
+			topic.setDescription("description");
+			topic.setEndpointType("broker");
+			topic.setId(999L);
+			topic.setPartitionCount(2);
+			topic.setStatus("Y");
+			topic.setStorageType("mysql");
+
+			Partition partition = new Partition();
+			partition.setEndpoint("br0");
+			partition.setId(1);
+			partition.setReadDatasource("br0");
+			partition.setWriteDatasource("br0");
+			topic.addPartition(partition);
+			return topic;
+		}
+
+		protected static Topic buildUpdatedTopic(Topic topic) {
+			topic.setAckTimeoutSeconds(555);
+			topic.setCodecType("JSON");
+			topic.setConsumerRetryPolicy("1:[3,6,9]");
+			topic.setCreateBy("UPDATED");
+			topic.setCreateTime(new Date());
+			topic.setDescription("DESCRIPTION");
+			topic.setEndpointType("BR0");
+			topic.setId(111L);
+			topic.setPartitionCount(2);
+			topic.setStatus("Y");
+			topic.setStorageType("MYSQL");
+			return topic;
+		}
+	}
+
+	static class MetaHelper {
+		public static Meta loadMeta() throws Exception {
+			return loadMeta(metaXmlFile);
+		}
+
+		public static Meta loadMeta(String fileName) throws Exception {
+			InputStream in = null;
+			File file;
+			file = new File("src/test/resources/" + fileName);
+			if (!file.exists()) {
+				file = new File("hermes-metaserver/src/test/resources/" + fileName);
+			}
+
+			if (file.exists()) {
+				in = new FileInputStream(file);
+			}
+
+			if (in == null) {
+				throw new RuntimeException(String.format("File %s not found in classpath.", fileName));
+			} else {
+				try {
+					return DefaultSaxParser.parse(in);
+				} catch (SAXException | IOException e) {
+					throw new RuntimeException(String.format("Error parse meta file %s", fileName), e);
+				}
+			}
+		}
+
+		private static void outputToTestXml(Meta meta) {
+			DefaultXmlBuilder builder = new DefaultXmlBuilder();
+			try {
+				PrintWriter output;
+				try {
+					output = new PrintWriter("src/test/resources/" + metaXmlFile);
+				} catch (FileNotFoundException e) {
+					output = new PrintWriter("hermes-metaserver/src/test/resources/" + metaXmlFile);
+				}
+				output.println(builder.buildXml(meta));
+				output.flush();
+			} catch (Exception ex) {
+				logger.error("Error in output xml file, {}", ex);
+			}
+		}
+	}
+
+	static class BaseRestClient {
+
+		public static Meta getMeta(int port) {
+			WebTarget webTarget = getWebTarget(port);
+			return webTarget.path("/meta").request().get().readEntity(Meta.class);
+		}
+
+		public static List<String> getMetaServers(int port) {
+			WebTarget webTarget = getWebTarget(port);
+			return (List<String>) webTarget.path("/metaserver/servers").request().get().readEntity(List.class);
+		}
+
+		// can't parse JSON.parseObject(json, MetaServerResource.MetaStatusStatusResponse.class)
+		// HermesClassLoader problem.
+		// so have to parse into map/JsonObject...
+		public static MetaStatusStatusResponse getMetaStatusLeaderInfo(int port) throws IOException {
+			WebTarget webTarget = getWebTarget(port);
+			Map map = webTarget.path("/metaserver/status").request().get().
+					  readEntity(Map.class);
+
+			MetaStatusStatusResponse re = new MetaStatusStatusResponse();
+			re.setLeader((Boolean) map.get("leader"));
+			Map map2 = (Map) map.get("leaderInfo");
+			HostPort hostport = new HostPort((String) map2.get("host"), (Integer) map2.get("port"));
+			re.setLeaderInfo(hostport);
+
+			return re;
+		}
+
+		public static MetaStatusStatusResponse getMetaStatusBrokerAssignment(int port) throws IOException {
+			WebTarget webTarget = getWebTarget(port);
+			Map map = webTarget.path("/metaserver/status").request().get().
+					  readEntity(Map.class);
+
+			MetaStatusStatusResponse re = new MetaStatusStatusResponse();
+			Map<String, Assignment<Integer>> assignment = JSON.parseObject(JSON.toJSONString(map.get("brokerAssignments")),
+					  new TypeReference<Map<String, Assignment<Integer>>>() {
+					  }.getType());
+
+			re.setLeader((boolean) map.get("leader"));
+			re.setBrokerAssignments(assignment);
+			return re;
+		}
+
+		public static MetaStatusStatusResponse getMetaStatusMetaServerAssignment(int port) throws IOException {
+			WebTarget webTarget = getWebTarget(port);
+			Map map = webTarget.path("/metaserver/status").request().get().readEntity(Map.class);
+
+			MetaStatusStatusResponse re = new MetaStatusStatusResponse();
+
+			Assignment<String> assignment = JSON.parseObject(JSON.toJSONString(map.get("metaServerAssignments")),
+					  new TypeReference<Assignment<String>>() {
+					  }.getType());
+			re.setMetaServerAssignments(assignment);
+			return re;
+		}
+
+		public static LeaseAcquireResponse getAcquireBrokerLease(String topic, int partition, String sessionId,
+																					int brokerPort, int metaServerPort) throws IOException, URISyntaxException {
+			return getBrokerLease("/lease/broker/acquire", topic, partition, null, sessionId, brokerPort, metaServerPort);
+		}
+
+		public static LeaseAcquireResponse getRenewBrokerLease(String topic, int partition, long leaseId, String
+				  sessionId, int brokerPort, int metaServerPort) throws IOException, URISyntaxException {
+			return getBrokerLease("/lease/broker/renew", topic, partition, leaseId, sessionId, brokerPort, metaServerPort);
+		}
+
+		public static LeaseAcquireResponse getAcquireConsumerLease(int metaServerPort, Tpg tpg) throws IOException, URISyntaxException {
+			return getConsumerLease("/lease/consumer/acquire", "WRONG SESSION", null, tpg, metaServerPort);
+		}
+
+		public static LeaseAcquireResponse getRenewConsumerLease(int metaServerPort, long leaseId, Tpg tpg) throws
+				  IOException, URISyntaxException {
+			return getConsumerLease("/lease/consumer/renew", "WRONG SESSION", leaseId, tpg, metaServerPort);
+
+		}
+
+		static ObjectMapper om = new ObjectMapper();
+
+		public static LeaseAcquireResponse getConsumerLease(String uri, String sessionId, Long leaseId,
+																			 Tpg tpg, int metaServerPort) throws
+				  URISyntaxException, IOException {
+			URIBuilder uriBuilder = new URIBuilder()//
+					  .setScheme("http")//
+					  .setHost(localhostIP)//
+					  .setPort(metaServerPort)//
+					  .setPath(uri);
+
+			Map<String, String> params = new HashMap<>();
+			params.put("sessionId", sessionId);
+			params.put("host", localhostIP);
+
+			if (null != leaseId) {
+				params.put("leaseId", Long.toString(leaseId));
+			}
+			for (Map.Entry<String, String> entry : params.entrySet()) {
+				uriBuilder.addParameter(entry.getKey(), entry.getValue());
+			}
+
+			return getLeaseAcquireResponse(uriBuilder, tpg);
+		}
+
+
+		public static LeaseAcquireResponse getBrokerLease(String uri, String topic, int partition, Long leaseId, String
+				  sessionId, int brokerPort, int metaServerPort) throws URISyntaxException, IOException {
+			URIBuilder uriBuilder = new URIBuilder()//
+					  .setScheme("http")//
+					  .setHost(localhostIP)//
+					  .setPort(metaServerPort)//
+					  .setPath(uri);
+
+			Map<String, String> params = new HashMap<>();
+			params.put("topic", topic);
+			params.put("partition", Integer.toString(partition));
+			params.put("sessionId", sessionId);
+			params.put("brokerPort", Integer.toString(brokerPort));
+			params.put("host", localhostIP);
+
+			if (null != leaseId) {
+				params.put("leaseId", Long.toString(leaseId));
+			}
+			for (Map.Entry<String, String> entry : params.entrySet()) {
+				uriBuilder.addParameter(entry.getKey(), entry.getValue());
+			}
+
+			return getLeaseAcquireResponse(uriBuilder, null);
+		}
+
+		private static LeaseAcquireResponse getLeaseAcquireResponse(URIBuilder uriBuilder, Object payload) throws
+				  IOException, URISyntaxException {
+			HttpResponse response;
+			if (payload != null) {
+				response = Request.Post(uriBuilder.build())//
+						  .bodyString(JSON.toJSONString(payload), ContentType.APPLICATION_JSON)//
+						  .execute()//
+						  .returnResponse();
+			} else {
+				response = Request.Post(uriBuilder.build())//
+						  .execute()//
+						  .returnResponse();
+			}
+
+			if (response != null && response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
+				String responseContent = EntityUtils.toString(response.getEntity());
+				if (!StringUtils.isBlank(responseContent)) {
+
+					/**
+					 * trust me, you can't use:
+					 * JSON.parseObject(response, LeaseAcquireResponse.class);
+					 * you'll get Exception: "set property error, lease", "object is not an instance of declaring class"
+					 *
+					 * That's maybe caused by that Lease is loaded by HermesClassLoader,
+					 * same to the problem in MetaStatusStatusResponse.Assignment<String>.
+					 *
+					 * Unable to solve this. As we need HermesClassLoader to launch different Plexus,
+					 * so that we can run several metaservers at same time.
+					 */
+					return om.readValue(responseContent, LeaseAcquireResponse.class);
+				}
+			}
+			return null;
+		}
+
+		private static WebTarget getWebTarget(int port) {
+			Client client = ClientBuilder.newClient();
+			return client.target("http://127.0.0.1:" + port);
+		}
+	}
+}

--- a/hermes-metaserver/src/test/java/com/ctrip/hermes/metaserver/fulltest/MetaServerBrokerAssignmentTest.java
+++ b/hermes-metaserver/src/test/java/com/ctrip/hermes/metaserver/fulltest/MetaServerBrokerAssignmentTest.java
@@ -1,0 +1,80 @@
+package com.ctrip.hermes.metaserver.fulltest;
+
+import org.junit.Test;
+
+public class MetaServerBrokerAssignmentTest extends MetaServerBaseTest {
+
+	/**
+	 * 增减Topic, 分配到各Broker正确。
+	 */
+	@Test
+	public void testBrokerAssignment1() throws Exception {
+		int initServers = 2;
+		int brokerCount = 3;
+		int topicCount = 3;
+
+		// init
+		startMultipleMetaServers(initServers);
+		assertOnlyOneLeader();
+
+		mockBrokerRegisterToZK(brokerCount);
+
+		// add topic
+		for (int i = 0; i < topicCount; i++) {
+			addOneTopicToMeta();
+
+			assertBrokerAssignmentRight();
+		}
+
+		// remove topic
+		for (int i = 0; i < topicCount; i++) {
+			removeOneTopicFromMeta();
+			assertBrokerAssignmentRight();
+		}
+
+		mockBrokerAllUnRegisterToZK();
+
+		// stop all servers
+		stopMultipleMetaServersRandomly(initServers);
+		assertAllStopped();
+	}
+
+
+	/**
+	 * 增减Broker,分配到各Broker正确。
+	 */
+	@Test
+	public void testBrokerAssignment2() throws Exception {
+		int initServers = 2;
+		int brokerCount = 3;
+		int topicCount = 5;
+
+		// init
+		startMultipleMetaServers(initServers);
+		assertOnlyOneLeader();
+
+		// add topic
+		for (int i = 0; i < topicCount; i++) {
+			addOneTopicToMeta();
+		}
+
+		mockBrokerRegisterToZK(brokerCount);
+
+		// broker was registered by one by one. need Time for service discovery
+		Thread.sleep(brokerCount * 500);
+		assertBrokerAssignmentRight();
+
+		mockBrokerAllUnRegisterToZK();
+		assertBrokerAssignmentRight();
+
+		// remove topic
+		for (int i = 0; i < topicCount; i++) {
+			removeOneTopicFromMeta();
+			assertBrokerAssignmentRight();
+		}
+
+		// stop all servers
+		stopMultipleMetaServersRandomly(initServers);
+		assertAllStopped();
+	}
+}

--- a/hermes-metaserver/src/test/java/com/ctrip/hermes/metaserver/fulltest/MetaServerBrokerLeaseTest.java
+++ b/hermes-metaserver/src/test/java/com/ctrip/hermes/metaserver/fulltest/MetaServerBrokerLeaseTest.java
@@ -1,0 +1,209 @@
+package com.ctrip.hermes.metaserver.fulltest;
+
+import org.junit.Test;
+
+import com.ctrip.hermes.core.lease.Lease;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class MetaServerBrokerLeaseTest extends MetaServerBaseTest  {
+
+	/**
+	 * Basic Broker Lease:
+	 * 对于分配好的Broker: 任意时间acquire都成功
+	 * 到期前 renew 成功
+	 * 到期后 renew 失败
+	 */
+	@Test
+	public void brokerLeaseBasicTest() throws Exception {
+		final String topic = "meta_test_1";
+		final int partition = 0;
+
+		int brokerPort = mockBrokerRegisterToZK(1).get(0);
+		final String sessionId = String.valueOf(brokerPort);
+
+		startMultipleMetaServers(1);
+
+		Lease lease = initLeaseToBroker(brokerPort, topic, 0, sessionId);
+		assertNotNull(lease);
+		long leaseId = lease.getId();
+
+		// Before timeout: acquire true, renew true
+		assertAcquireBrokerLeaseOnAll(true, brokerPort, topic, partition, sessionId);
+		assertRenewBrokerLeaseOnAll(true, brokerPort, topic, partition, leaseId, sessionId);
+
+		waitOneLeaseTime();
+		assertTrue(lease.isExpired());
+
+		// But still need to wait 5 second to BaseLeaseHolder.startHouseKeeper()
+		Thread.sleep(5000);
+
+		// After timeout: renew fail, acquire true, renew true;
+		assertRenewBrokerLeaseOnAll(false, brokerPort, topic, partition, leaseId, sessionId);
+		assertAcquireBrokerLeaseOnAll(true, brokerPort, topic, partition, sessionId);
+		assertRenewBrokerLeaseOnAll(true, brokerPort, topic, partition, leaseId + 1, sessionId);
+
+		stopMultipleMetaServersRandomly(1);
+		assertAllStopped();
+	}
+
+
+	/**
+	 * Broker Lease: 基本acquire和renew功能
+	 * 1) 初始：Broker1 获得Topic1的Lease, 另有Broker2
+	 * 2) 则
+	 * 1) 到期前：
+	 * Broker1 acquire Topic1 True
+	 * Broker1 renew Topic1 True and added Lease Timeout Time!
+	 * Broker2 acquire Topic1 Fail
+	 * Broker2 renew Topic1 Fail
+	 * 2) 到期后：
+	 * Broker2 acquire Topic1 Fail
+	 * Broker2 renew Topic1 Fail
+	 * Broker1 acquire Topic1 True
+	 * Broker1 renew Topic1 True
+	 * <p/>
+	 * 目标MetaServer覆盖Leader, Follower
+	 */
+	@Test
+	public void testBrokerLeaseAcquireAndRenew() throws Exception {
+		final String topic = "meta_test_1";
+		final int partition = 0;
+		final int metaServerCount = 4;
+		// init
+		startMultipleMetaServers(1);  // make localhost:1248 to be the leader
+		startMultipleMetaServers(metaServerCount - 1);
+
+		int brokerPort1 = mockBrokerRegisterToZK(1).get(0);
+		String brokerSession1 = String.valueOf(brokerPort1);
+
+		Thread.sleep(500); // for ZK discovery broke
+		Lease lease = initLeaseToBroker(brokerPort1, topic, partition, brokerSession1);
+		assertNotNull(lease);
+		long leaseId = lease.getId();
+
+		// Before timeout: Broker1: acquire true, renew true
+		assertAcquireBrokerLeaseOnAll(true, brokerPort1, topic, partition, brokerSession1);
+		assertRenewBrokerLeaseOnAll(true, brokerPort1, topic, partition, leaseId, brokerSession1);
+
+		// Mock Broker2
+		int brokerPort2 = mockBrokerRegisterToZK(1).get(0);
+		String brokerSession2 = String.valueOf(brokerPort2);
+		Lease lease2 = initLeaseToBroker(brokerPort2, topic, partition, brokerSession2);
+		assertNull(lease2);
+
+		// Before timeout: Broker2: acquire false, renew false
+		assertAcquireBrokerLeaseOnAll(false, brokerPort2, topic, partition, brokerSession2);
+		assertRenewBrokerLeaseOnAll(false, brokerPort2, topic, partition, leaseId, brokerSession2);
+
+		// Lease has been renewed in every meta server!
+		for (int i = 0; i < metaServerCount; i++) {
+			waitOneLeaseTime();
+		}
+		assertTrue(lease.isExpired());
+		// But still need to wait 5 second to BaseLeaseHolder.startHouseKeeper()
+		Thread.sleep(5100);
+
+		// After timeout: Broker1: renew fail, acquire true, renew true;
+		assertRenewBrokerLeaseOnAll(false, brokerPort1, topic, partition, leaseId, brokerSession1);
+		assertAcquireBrokerLeaseOnAll(true, brokerPort1, topic, partition, brokerSession1);
+		assertRenewBrokerLeaseOnAll(true, brokerPort1, topic, partition, leaseId + 1, brokerSession1);
+
+		// After timeout: Broker2: renew fail, acquire fail;
+		assertRenewBrokerLeaseOnAll(false, brokerPort2, topic, partition, leaseId, brokerSession2);
+		assertAcquireBrokerLeaseOnAll(false, brokerPort2, topic, partition, brokerSession2);
+
+		// stop all servers
+		stopMultipleMetaServersRandomly(metaServerCount);
+		assertAllStopped();
+	}
+
+
+	/**
+	 * Broker Lease: 切换功能
+	 * 1) 初始：Broker1 获得Topic的Lease, 另有Broker2
+	 * 2) 期间通过修改zk,将Lease分配到Broker2
+	 * 3) 则
+	 * 1) 到期前：
+	 * Broker1 acquire Topic1 True
+	 * Broker1 renew Topic1 True
+	 * Broker2 acquire Topic1 False
+	 * Broker2 renew Topic1 False
+	 * 2) (修改Lease Session到Broker2)后：
+	 * Broker1 acquire Topic1 Fail (???)
+	 * Broker1 renew Topic1 fail
+	 * Broker2 acquire Topic1 Success
+	 * Broker2 renew Topic1 True
+	 * (Broker2到期后)
+	 * Broker2 acquire Topic1 True
+	 * <p/>
+	 * 目标MetaServer覆盖Leader, Follower
+	 */
+
+	@Test
+	public void testBrokerLeaseChanged() throws Exception {
+		final String topic = "meta_test_1";
+		final int partition = 0;
+		final int metaServerCount = 2;
+
+		// init
+		startMultipleMetaServers(1);  // make localhost:1248 to be the leader
+		startMultipleMetaServers(metaServerCount - 1);
+
+		int brokerPort1 = mockBrokerRegisterToZK(1).get(0);
+		String brokerSession1 = String.valueOf(brokerPort1);
+
+		Thread.sleep(500); // for ZK discovery broker
+		Lease lease = initLeaseToBroker(brokerPort1, topic, partition, brokerSession1);
+		assertNotNull(lease);
+		long leaseId = lease.getId();
+
+		// Before change: Broker1: acquire true, renew true
+		assertAcquireBrokerLeaseOnAll(true, brokerPort1, topic, partition, brokerSession1);
+		assertRenewBrokerLeaseOnAll(true, brokerPort1, topic, partition, leaseId, brokerSession1);
+
+		// Mock Broker2
+		int brokerPort2 = mockBrokerRegisterToZK(1).get(0);
+		String brokerSession2 = String.valueOf(brokerPort2);
+		Lease lease2 = initLeaseToBroker(brokerPort2, topic, partition, brokerSession2);
+		assertNull(lease2);
+
+		// Notice that in changeLeaseTo, it set one Lease(id=1) to ZK,
+		// which is same to prior Lease by coincidence.
+		// 'cause lookup(BrokerLeaseHolder.class) are not the one of MetaServers' BrokerLeaseHolder !
+
+		changeLeaseTo(brokerPort1, brokerPort2, topic, partition, MockMetaServerConfig.BROKER_LEASE_TIMEOUT);
+		Thread.sleep(3000);
+//		assertFalse(lease.isExpired());
+		// After change: Broker1: acquire false, renew false;
+		assertAcquireBrokerLeaseOnAll(false, brokerPort1, topic, partition, brokerSession1);
+		assertRenewBrokerLeaseOnAll(false, brokerPort1, topic, partition, leaseId, brokerSession1);
+
+		// After change but before timeout: Broker2: acquire false, renew false;
+		assertAcquireBrokerLeaseOnAll(false, brokerPort2, topic, partition, brokerSession2);
+		assertRenewBrokerLeaseOnAll(false, brokerPort2, topic, partition, leaseId, brokerSession2);
+
+		for (int i = 0; i < metaServerCount; i++) {
+			waitOneLeaseTime();
+		}
+
+		assertTrue(lease.isExpired());
+		// But still need to wait 5 second to BaseLeaseHolder.startHouseKeeper()
+		Thread.sleep(6000);
+
+		// After timeout: Broker1: acquire false, renew false;
+		assertAcquireBrokerLeaseOnAll(false, brokerPort1, topic, partition, brokerSession1);
+		assertRenewBrokerLeaseOnAll(false, brokerPort1, topic, partition, leaseId + 1, brokerSession1);
+
+		// After timeout: Broker2: renew true, acquire true;
+		assertRenewBrokerLeaseOnAll(false, brokerPort2, topic, partition, leaseId, brokerSession2);
+		assertAcquireBrokerLeaseOnAll(true, brokerPort2, topic, partition, brokerSession2);
+		assertRenewBrokerLeaseOnAll(true, brokerPort2, topic, partition, leaseId + 1, brokerSession2);
+
+		// stop all servers
+		stopMultipleMetaServersRandomly(metaServerCount);
+		assertAllStopped();
+	}
+}

--- a/hermes-metaserver/src/test/java/com/ctrip/hermes/metaserver/fulltest/MetaServerConsumerLeaseTest.java
+++ b/hermes-metaserver/src/test/java/com/ctrip/hermes/metaserver/fulltest/MetaServerConsumerLeaseTest.java
@@ -1,0 +1,119 @@
+package com.ctrip.hermes.metaserver.fulltest;
+
+import org.junit.Test;
+
+/**
+ * 所有测试output，都需检查所有MetaServer的Rest(/meta, /metaserver/status) output，以及ZK中相应字段！
+ */
+public class MetaServerConsumerLeaseTest extends MetaServerBaseTest {
+
+	/**
+	 * Consumer Lease: Basic
+	 */
+
+	@Test
+	public void testOrderConsumerAcquire() throws Exception {
+		final String topic = "meta_test_1";
+		final String group = "meta_test_order_group";
+		final int metaServerCount = 2;
+
+		// init
+		startMultipleMetaServers(1);  // make localhost:1248 to be the leader
+		startMultipleMetaServers(metaServerCount - 1);
+
+		// mock one broker
+		int brokerPort = mockBrokerRegisterToZK(1).get(0);
+		final String sessionId = String.valueOf(brokerPort);
+
+
+		initLeaseToBroker(brokerPort, topic, 0, sessionId);
+
+		assertAcquireConsumerLeaseOnAll(true, topic, group);
+		assertRenewConsumerLeaseOnAll(true, 1, topic, group);
+	}
+
+	@Test
+	public void testNonOrderConsumerAcquire() throws Exception {
+		final String topic = "meta_test_1";
+		final String group = "meta_test_non_order_group";
+		final int metaServerCount = 2;
+
+		// init
+		startMultipleMetaServers(1);  // make localhost:1248 to be the leader
+		startMultipleMetaServers(metaServerCount - 1);
+
+		// mock one broker
+		int brokerPort = mockBrokerRegisterToZK(1).get(0);
+		final String sessionId = String.valueOf(brokerPort);
+
+
+		initLeaseToBroker(brokerPort, topic, 0, sessionId);
+
+		Thread.sleep(1000);
+		assertAcquireConsumerLeaseOnAll(true, topic, group);
+		assertRenewConsumerLeaseOnAll(true, 1, topic, group);
+	}
+
+	/**
+	 * Test: Meta Server 变化的情况下，仍能正确拿到Lease
+	 * 模拟场景：Leader 1248, Follower 1249 变成 Leader 1249, Follower 1248, 仍正确Lease。
+	 */
+	@Test
+	public void testOrderConsumerChange() throws Exception {
+		final String topic = "meta_test_1";
+		final String group = "meta_test_order_group";
+		final int metaServerCount = 2;
+
+		// init
+		startMultipleMetaServers(1);  // make localhost:1248 to be the leader
+		startMultipleMetaServers(metaServerCount - 1);
+
+		// mock one broker
+		int brokerPort = mockBrokerRegisterToZK(1).get(0);
+		final String sessionId = String.valueOf(brokerPort);
+
+
+		initLeaseToBroker(brokerPort, topic, 0, sessionId);
+		Thread.sleep(2000);
+
+		assertAcquireConsumerLeaseOnAll(true, topic, group);
+		assertRenewConsumerLeaseOnAll(true, 1, topic, group);
+
+		stopMetaServer(1248);
+		startMetaServer(1248);
+		Thread.sleep(2000);
+
+		assertAcquireConsumerLeaseOnAll(true, topic, group);
+		assertRenewConsumerLeaseOnAll(true, 1, topic, group);
+
+	}
+
+	//
+	@Test
+	public void testNonOrderConsumerChange() throws Exception {
+		final String topic = "meta_test_1";
+		final String group = "meta_test_non_order_group";
+		final int metaServerCount = 2;
+
+		// init
+		startMultipleMetaServers(1);  // make localhost:1248 to be the leader
+		startMultipleMetaServers(metaServerCount - 1);
+
+		// mock one broker
+		int brokerPort = mockBrokerRegisterToZK(1).get(0);
+		final String sessionId = String.valueOf(brokerPort);
+
+
+		initLeaseToBroker(brokerPort, topic, 0, sessionId);
+
+		assertAcquireConsumerLeaseOnAll(true, topic, group);
+		assertRenewConsumerLeaseOnAll(true, 1, topic, group);
+
+		stopMetaServer(1248);
+		startMetaServer(1248);
+		Thread.sleep(2000);
+
+		assertAcquireConsumerLeaseOnAll(true, topic, group);
+		assertRenewConsumerLeaseOnAll(true, 1, topic, group);
+	}
+}

--- a/hermes-metaserver/src/test/java/com/ctrip/hermes/metaserver/fulltest/MetaServerLeadershipTest.java
+++ b/hermes-metaserver/src/test/java/com/ctrip/hermes/metaserver/fulltest/MetaServerLeadershipTest.java
@@ -1,0 +1,51 @@
+package com.ctrip.hermes.metaserver.fulltest;
+
+import org.junit.Test;
+
+public class MetaServerLeadershipTest extends MetaServerBaseTest {
+
+	/**
+	 * 0. Basic Functions
+	 */
+	@Test
+	public void startAndStopMultipleMetaServerAtOneTime() throws Exception {
+
+		startMultipleMetaServers(5);
+
+		Thread.sleep(3000);
+		stopMultipleMetaServersRandomly(4);
+		stopMultipleMetaServersRandomly(1);
+
+		assertAllStopped();
+	}
+
+	/**
+	 * 1. Leader Election:
+	 * 多个MetaServer,时起时停,保证有且仅有一个Leader
+	 */
+	@Test
+	public void testOnlyOneLeaderAllTime() throws Exception {
+		int totalServers = 3;
+		int initServers = 2;
+
+		// init
+		startMultipleMetaServers(initServers);
+		assertOnlyOneLeader();
+
+		// add one MetaServer one time.
+		for (int i = 0; i < (totalServers - initServers); i++) {
+			startMultipleMetaServers(1);
+			assertOnlyOneLeader();
+		}
+
+		// stop one MetaServer one time.
+		for (int i = totalServers; i > 0; i--) {
+			stopMultipleMetaServersRandomly(1);
+			if (i > 1) {
+				assertOnlyOneLeader();
+			}
+		}
+
+		assertAllStopped();
+	}
+}

--- a/hermes-metaserver/src/test/java/com/ctrip/hermes/metaserver/fulltest/MockClientEnviroment.java
+++ b/hermes-metaserver/src/test/java/com/ctrip/hermes/metaserver/fulltest/MockClientEnviroment.java
@@ -1,0 +1,11 @@
+package com.ctrip.hermes.metaserver.fulltest;
+
+import com.ctrip.hermes.core.env.DefaultClientEnvironment;
+
+public class MockClientEnviroment extends DefaultClientEnvironment {
+
+	@Override
+	public String getMetaServerDomainName() {
+		return "127.0.0.1";
+	}
+}

--- a/hermes-metaserver/src/test/java/com/ctrip/hermes/metaserver/fulltest/MockMetaServerConfig.java
+++ b/hermes-metaserver/src/test/java/com/ctrip/hermes/metaserver/fulltest/MockMetaServerConfig.java
@@ -1,0 +1,31 @@
+package com.ctrip.hermes.metaserver.fulltest;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.ctrip.hermes.core.utils.StringUtils;
+import com.ctrip.hermes.metaserver.config.MetaServerConfig;
+
+public class MockMetaServerConfig extends MetaServerConfig {
+
+	public static long BROKER_LEASE_TIMEOUT= 5000;
+
+	int port;
+	@Override
+	public int getMetaServerPort() {
+		return port;
+	}
+
+	public void setPort(int port) {
+		this.port = port;
+	}
+
+	@Override
+	public long getBrokerLeaseTimeMillis() {
+		return BROKER_LEASE_TIMEOUT;
+	}
+
+	public static void  setBrokerLeaseTimeout(long timeout) {
+		BROKER_LEASE_TIMEOUT = timeout;
+	}
+}

--- a/hermes-metaserver/src/test/java/com/ctrip/hermes/metaserver/fulltest/MockMetaService.java
+++ b/hermes-metaserver/src/test/java/com/ctrip/hermes/metaserver/fulltest/MockMetaService.java
@@ -1,0 +1,33 @@
+package com.ctrip.hermes.metaserver.fulltest;
+
+import org.unidal.dal.jdbc.DalException;
+
+import com.ctrip.hermes.meta.entity.Meta;
+import com.ctrip.hermes.metaservice.service.MetaService;
+
+public class MockMetaService implements MetaService {
+
+	@Override
+	public Meta findLatestMeta() throws DalException {
+		Meta meta =null;
+			try {
+				 meta = loadMeta();
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
+		return meta;
+	}
+
+	@Override
+	public boolean updateMeta(Meta meta) throws DalException {
+		throw  new RuntimeException("not implemented in MockMetaService!");
+	}
+
+	protected Meta loadMeta() throws Exception {
+
+
+		String fileName = MetaServerBaseTest.metaXmlFile;
+
+		return MetaServerBaseTest.MetaHelper.loadMeta(fileName);
+	}
+}

--- a/hermes-metaserver/src/test/resources/MetaServerTest_Backup.xml
+++ b/hermes-metaserver/src/test/resources/MetaServerTest_Backup.xml
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<meta dev-mode='false' version='1'>
+
+    <topic name='meta_test_1' id='1' partition-count='1' storage-type='mysql' codec-type="json"
+           consumer-retry-policy="1:[2,4,6]"
+           endpoint-type="broker" ack-timeout-seconds="5">
+        <consumer-group id='1' name="meta_test_order_group" app-ids="1" retry-policy="1:[3,6,9,15]"
+                        ack-timeout-seconds="5" />
+        <consumer-group id='2' name="meta_test_non_order_group" app-ids="2" retry-policy="1:[5,10]"
+                        ack-timeout-seconds="6"
+                        ordered-consume="false" />
+        <partition id='0' endpoint='br0' />
+    </topic>
+
+	<codec type="json" />
+
+	<storage type='test'>
+	</storage>
+</meta>

--- a/hermes-metaserver/src/test/resources/log4j.xml
+++ b/hermes-metaserver/src/test/resources/log4j.xml
@@ -45,6 +45,56 @@
 		<appender-ref ref="CONSOLE" />
 	</logger>
 
+    <!-- to clean output in debugging-->
+    <logger name="com.ctrip.hermes.core.env">
+        <level value="WARN" />
+        <appender-ref ref="CONSOLE" />
+    </logger>
+
+    <logger name="com.dianping">
+        <level value="ERROR" />
+        <appender-ref ref="CONSOLE" />
+    </logger>
+
+    <logger name="org.apache.curator">
+        <level value="ERROR" />
+        <appender-ref ref="CONSOLE" />
+    </logger>
+
+    <logger name="com.ctrip.hermes.metaserver.commons.BaseLeaseHolder">
+        <level value="ERROR" />
+        <appender-ref ref="CONSOLE" />
+    </logger>
+
+    <logger name="org.apache.curator.framework.imps">
+        <level value="FATAL" />
+        <appender-ref ref="CONSOLE" />
+    </logger>
+
+    <logger name="org.apache.curator.ConnectionState">
+        <level value="FATAL" />
+        <appender-ref ref="CONSOLE" />
+    </logger>
+    <logger name="com.ctrip.hermes.metaserver.event.impl.LeaderInitEventHandler">
+        <level value="FATAL" />
+        <appender-ref ref="CONSOLE" />
+    </logger>
+
+    <logger name="com.ctrip.hermes.metaserver.event.impl.FollowerInitEventHandler">
+        <level value="FATAL" />
+        <appender-ref ref="CONSOLE" />
+    </logger>
+
+    <logger name="org.apache.zookeeper.ClientCnxn">
+        <level value="FATAL" />
+        <appender-ref ref="CONSOLE" />
+    </logger>
+
+
+    <logger name="com.ctrip.hermes.metaserver.meta.MetaServerAssignmentHolder">
+        <level value="FATAL" />
+        <appender-ref ref="CONSOLE" />
+    </logger>
 	<root>
 		<level value="INFO" />
 		<appender-ref ref="CONSOLE" />


### PR DESCRIPTION
1. 由于必须使用自定义的HermesClassLoader，才能同时使用多套Plexus的的DI框架，才能同时起多个MetaServer。而使用fastJson进行反序列化是，会错误加载一些类的ClassLoader,例如Lease, Assignment<>。暂时难以解决。

2. Lease: 需要加上Jsckson的@JsonIgnore，Lease才能正确被反序列话，如上原因，只能使用Jsckson来反序列化。

3. test下的log4j.xml 过滤了很多重连zookeeper的日志，会直接导致mvn test OOM。另一部分重连异常如：Unexpected Exception: java.nio.channels.CancelledKeyException，是ZK问题，如apache上的回答。

4. 在 DefaultMetaServerAssigningStrategy 中加入了检查metaserver的逻辑：否则在关闭meta server时会报一下异常： [ERROR] [com.ctrip.hermes.metaserver.event.DefaultEventBus] [EventBus-1] Exception occurred while processing event META_SERVER_LIST_CHANGED in handler MetaServerListChangedEventHandler java.lang.IndexOutOfBoundsException: Index: 0, Size: 0 at java.util.ArrayList.rangeCheck(ArrayList.java:635) at java.util.ArrayList.get(ArrayList.java:411) at com.ctrip.hermes.metaserver.meta.DefaultMetaServerAssigningStrategy.assign(DefaultMetaServerAssigningStrategy.java:34) ...